### PR TITLE
Update documentation and setup/start script for a better experience for first time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [documentation for the Content API](https://open-platform.theguardian.com/do
 
 🔌 Run `./script/setup`
 
-📝 Fill in `.env`
+📝 Fill in `.env` – see the template in `.env.example`. API keys can be acquired at `https://bonobo.capi.gutools.co.uk/register/developer`.
 
 🔌 Run `./script/start`
 


### PR DESCRIPTION
A few problems surfaced when a new user picked up this tool for the first time:

- The setup script runs `nvm use`, but the user may be in a different shell when running `start`
- It's not clear that the example creds file is present if the setup script
- It's not clear which endpoints the user should supply, or where to get an API key

This PR updates the docs to address these problems.

To do:

- [x] Confirm that endpoints can be baked into the repo