### PR TITLE
Pass through response code and error message, too

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -42,10 +42,10 @@ app.get('/preview/*', (req, res, next) => {
         Accept: 'application/json'
     };
 
-    fetch(capiUrl, { headers })
-        .then(_ => _.json())
-        .then(({ response }) => {
-            res.send(response);
+    return fetch(capiUrl, { headers })
+        .then(result => result.json().then(parsedJson => ({ parsedJson, result })))
+        .then(({ parsedJson, result }) => {
+          res.status(result.status).send(parsedJson.response || parsedJson.message);
         });
 });
 


### PR DESCRIPTION
## What does this change?

At the moment, if CAPI returns an error, the user receives a 200 message, and a blank page.

This PR carries through the status code from the CAPI response, and surfaces whatever's on `.message` if a `.response` is not present in the returned JSON, to surfaces errors that come back from CAPI.

For example, when AWS credentials are missing, before:

<img width="838" alt="Screenshot 2021-05-13 at 12 58 06" src="https://user-images.githubusercontent.com/7767575/118122530-e58eeb00-b3ea-11eb-8a1c-b8a5ca89ecda.png">

After:

<img width="838" alt="Screenshot 2021-05-13 at 12 57 48" src="https://user-images.githubusercontent.com/7767575/118122563-efb0e980-b3ea-11eb-936e-6d0dbd092e5c.png">

I couldn't find any documentation on error states in the documentation, so this PR assumes that any errors will be surfaced as `.message` in response JSON – lmk if that's not right!

## How to test

Run locally and induce an error, for example by removing AWS credentials `~/.aws/credentials`. You should see the error in the page, and the response code should be `403`.