### PR TITLE
Add more explicit instructions around local credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [documentation for the Content API](https://open-platform.theguardian.com/do
 
 📝 Fill in `.env`
 
-🎭 Make sure you have CAPI credentials from Janus
+🎭 [For preview] Make sure you have CAPI credentials from Janus
 
 🔌 Run `./script/start`
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [documentation for the Content API](https://open-platform.theguardian.com/do
 
 📝 Fill in `.env`
 
-🎭 [For preview] Make sure you have CAPI credentials from Janus
+🎭 [For preview] Make sure you have up-to-date AWS credentials for the 'Content API' account.
 
 🔌 Run `./script/start`
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ See [documentation for the Content API](https://open-platform.theguardian.com/do
 
 📝 Fill in `.env`
 
+🎭 Make sure you have CAPI credentials from Janus
+
 🔌 Run `./script/start`
 
 🌍 Open `https://capi-proxy.local.dev-gutools.co.uk` in your browser


### PR DESCRIPTION
## What does this change?

Preview needs CAPI credentials (see [IAMSigner.js](https://github.com/guardian/content-api-local-proxy/blob/master/src/IAMSigner.js)). Let's make this explicit for quicker setup.
